### PR TITLE
Added functionality to add a rectangular roi to the webmap. We will only process things within the roi.

### DIFF
--- a/include/wxWebMap.h
+++ b/include/wxWebMap.h
@@ -15,6 +15,16 @@
 #include    <wxMapUtil.h>
 #include    <list>
 
+// Used to store region of interest coordinates
+struct lat_lng_coords {
+    float lat;
+    float lng;
+};
+
+// Region of interest
+struct roi_rectangle {
+    lat_lng_coords Rectangle[4];
+};
 
 /**
  * @brief A window displaying a map from a map source, such as WMS.
@@ -113,9 +123,22 @@ public:
 
     virtual pwxMapObject Find(wxString const& result) = 0;
 
+    bool QueryLastSavedRectangle(roi_rectangle& Out) {
+        bool Result = false;
+
+        // Set only if first vertex has a value, consider adding better error checking?
+        if (LastSavedRectangle.Rectangle[0].lat != 0.f && LastSavedRectangle.Rectangle[0].lng != 0.f) {
+            Out = LastSavedRectangle;
+            Result = true;
+        }
+        return(Result);
+    }
+
 protected:
     /**
     * @brief Empty constructor.
     */
     wxWebMap();
+    //May be saved to the project file as a region of interest
+    roi_rectangle LastSavedRectangle = {};
 };


### PR DESCRIPTION
Please merge together with Studio, API and WebMap PR.

Added a rectangle struct which contains 4 lat/long coordinates. Added parsing of javascript rectangles. When a rectangle has been drawn in js, using the leaflet tool, we get a callback where we will parse those coordinates and store those in LastSavedRectangle. This rectangle will be queried from our main program to determine if we are within this ROI.

![rectangle_roi](https://github.com/I-CONIC-Vision-AB/wxWebMap/assets/19374211/0a457523-c57f-4a87-a7ad-ff1f71da2237)
