### PR TITLE
Remove warnings-as-errorsfor now

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,7 +24,7 @@
         "rhs": "Windows"
       },
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/W4 /WX /EHsc"
+        "CMAKE_CXX_FLAGS": "/W4 /EHsc"
       }
     },
     {


### PR DESCRIPTION
Makes wxWebMap compile.

But the actual issue is that a pointer can not be cast safely to an int which is done in
 wxMapMarker.cpp: cLeafletId = (int)this;